### PR TITLE
more open folder in filemanager support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+# travis build for APhotoManager
+language: android
+
+jdk:
+  - oraclejdk8
+
+addons:
+
+android:
+  components:
+    # https://github.com/travis-ci/travis-ci/issues/5036
+    - tools
+
+    # values in gradle.properties and .travis must be the same
+    # - build-tools-24.0.2
+    - build-tools-25.0.1
+    - android-26
+
+    - add-on
+    - extra
+
+before_install:
+# http://stackoverflow.com/questions/33820638/travis-yml-gradlew-permission-denied
+# must execute
+# git update-index --chmod=+x gradlew
+# instead of 
+# - chmod +x gradlew
+ 
+script:
+  - jdk_switcher use oraclejdk8
+  - ./gradlew assemble test

--- a/app/src/main/java/com/google/android/diskusage/DiskUsage.java
+++ b/app/src/main/java/com/google/android/diskusage/DiskUsage.java
@@ -21,13 +21,11 @@ package com.google.android.diskusage;
 
 import android.app.ActivityManager;
 import android.app.AlertDialog;
-import android.app.AppOpsManager;
 import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.ResolveInfo;
@@ -306,6 +304,87 @@ public class DiskUsage extends LoadableActivity {
     return res.size() > 0;
   }
 
+  private void openDirectoryInFilemanager(Uri uri) {
+    if (viewDirectoryInFilemanager(uri,
+            DocumentsContract.Document.MIME_TYPE_DIR,  // = "vnd.android.document/directory" since android api-19
+            "vnd.android.cursor.item/com.metago.filemanager.dir", // old Astro
+            "resource/folder", // EsFileExplorer and others  https://stackoverflow.com/questions/17165972/android-how-to-open-a-specific-folder-via-intent-and-show-its-content-in-a-file
+            "inode/directory" // https://stackoverflow.com/questions/18869772/mime-type-for-a-directory
+            // "text/direcotry" this would conflict with text editors also mentioned in https://stackoverflow.com/questions/18869772/mime-type-for-a-directory
+    )) return;
+    Intent intent;
+
+    intent = new Intent("org.openintents.action.VIEW_DIRECTORY");
+    intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    intent.setData(uri);
+
+    try {
+      startActivity(intent);
+      return;
+    } catch(ActivityNotFoundException|FileUriExposedException e) {
+    }
+
+    intent = new Intent("org.openintents.action.PICK_DIRECTORY");
+    intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    intent.setData(uri);
+    intent.putExtra("org.openintents.extra.TITLE",
+            str(R.string.title_in_oi_file_manager));
+    intent.putExtra("org.openintents.extra.BUTTON_TEXT",
+            str(R.string.button_text_in_oi_file_manager));
+
+    try {
+      startActivity(intent);
+      return;
+    } catch(ActivityNotFoundException|FileUriExposedException e) {
+    }
+
+    final Intent installSolidExplorer = new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=pl.solidexplorer"));
+
+    if (isIntentAvailable(installSolidExplorer)) {
+      new AlertDialog.Builder(this)
+              .setCancelable(true)
+              .setTitle("Missing compatible file manager")
+              .setMessage("No compatible filemanager found.\n\nAsk you favorite file manager developer " +
+                      "for integration with DiskUsage or install:" +
+                      "\n * Solid Explorer" +
+                      "\n * OI File Manager")
+              .setPositiveButton("Install Solid Explorer", new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface arg0, int arg1) {
+                  startActivity(installSolidExplorer);
+                }
+              })
+              .setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface arg0, int arg1) {
+                  // pass
+                }
+              })
+              .create().show();
+    } else {
+      Toast.makeText(this, str(R.string.install_oi_file_manager),
+              Toast.LENGTH_SHORT).show();
+    }
+    return;
+  }
+
+  private boolean viewDirectoryInFilemanager(Uri uri, String... mimes) {
+    Intent intent;
+    for (String mime : mimes) {
+      intent = new Intent(Intent.ACTION_VIEW);
+      intent.addCategory(Intent.CATEGORY_OPENABLE);
+      intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      intent.setDataAndType(uri, mime);
+
+      try {
+        startActivity(intent);
+        return true;
+      } catch (ActivityNotFoundException | FileUriExposedException e) {
+      }
+    }
+    return false;
+  }
+
   public void view(FileSystemEntry entry) {
     Intent intent = new Intent(Intent.ACTION_VIEW);
     intent.addCategory(Intent.CATEGORY_DEFAULT);
@@ -327,80 +406,7 @@ public class DiskUsage extends LoadableActivity {
     Uri uri = Uri.fromFile(file);
 
     if (file.isDirectory()) {
-      intent = new Intent(Intent.ACTION_VIEW);
-      intent.addCategory(Intent.CATEGORY_OPENABLE);
-      intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-      intent.setDataAndType(uri, DocumentsContract.Document.MIME_TYPE_DIR);
-
-      try {
-        startActivity(intent);
-        return;
-      } catch(ActivityNotFoundException|FileUriExposedException e) {
-      }
-
-      intent = new Intent("org.openintents.action.VIEW_DIRECTORY");
-      intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-      intent.setData(uri);
-
-      try {
-        startActivity(intent);
-        return;
-      } catch(ActivityNotFoundException|FileUriExposedException e) {
-      }
-
-      intent = new Intent("org.openintents.action.PICK_DIRECTORY");
-      intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-      intent.setData(uri);
-      intent.putExtra("org.openintents.extra.TITLE",
-          str(R.string.title_in_oi_file_manager));
-      intent.putExtra("org.openintents.extra.BUTTON_TEXT",
-          str(R.string.button_text_in_oi_file_manager));
-
-      try {
-        startActivity(intent);
-        return;
-      } catch(ActivityNotFoundException|FileUriExposedException e) {
-      }
-
-      // old Astro
-      intent = new Intent(Intent.ACTION_VIEW);
-      intent.addCategory(Intent.CATEGORY_DEFAULT);
-      intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-      intent.setDataAndType(uri, "vnd.android.cursor.item/com.metago.filemanager.dir");
-
-      try {
-        startActivity(intent);
-        return;
-      } catch(ActivityNotFoundException|FileUriExposedException e) {
-      }
-
-      final Intent installSolidExplorer = new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=pl.solidexplorer"));
-
-      if (isIntentAvailable(installSolidExplorer)) {
-        new AlertDialog.Builder(this)
-        .setCancelable(true)
-        .setTitle("Missing compatible file manager")
-        .setMessage("No compatible filemanager found.\n\nAsk you favorite file manager developer " +
-            "for integration with DiskUsage or install:" +
-            "\n * Solid Explorer" +
-            "\n * OI File Manager")
-            .setPositiveButton("Install Solid Explorer", new DialogInterface.OnClickListener() {
-              @Override
-              public void onClick(DialogInterface arg0, int arg1) {
-                startActivity(installSolidExplorer);
-              }
-            })
-            .setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
-              @Override
-              public void onClick(DialogInterface arg0, int arg1) {
-                // pass
-              }
-            })
-            .create().show();
-      } else {
-      Toast.makeText(this, str(R.string.install_oi_file_manager),
-          Toast.LENGTH_SHORT).show();
-      }
+      openDirectoryInFilemanager(uri);
       return;
     }
 


### PR DESCRIPTION
changes:

* added travis buildserver support ( see https://travis-ci.org/k3b/diskusage/branches )
* more open directory in filemanager support

---

outside this merge request I also created a branch api14 in my local repository so i can continue using diskusage on my android-4.2
which is not possible any more with 4.x version which requieres api-26
