### PR TITLE
Fix #67

### DIFF
--- a/app/src/main/java/com/google/android/diskusage/Apps2SDLoader.java
+++ b/app/src/main/java/com/google/android/diskusage/Apps2SDLoader.java
@@ -119,8 +119,6 @@ public class Apps2SDLoader {
     FileSystemEntry[] result = entries.toArray(new FileSystemEntry[] {});
     Arrays.sort(result, FileSystemEntry.COMPARE);
     handler.removeCallbacks(progressUpdater);
-    StructStatVfs a = Os.statvfs("/sdcard");
-    StructStat s = Os.stat("/sdcard");
     return result;
   }
 }


### PR DESCRIPTION
Removed two unused variables (maybe they were left for debug purposes?) since `Os.statvfs("/sdcard")` was throwing an Exception with no apparent intended consequences.

This change fixes the situation described in #67 