### PR TITLE
[WIP] Fix DocumentsUI integration

### DIFF
--- a/app/src/main/java/com/google/android/diskusage/ui/DiskUsage.java
+++ b/app/src/main/java/com/google/android/diskusage/ui/DiskUsage.java
@@ -28,21 +28,17 @@ import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.FileUriExposedException;
 import android.os.Handler;
-import android.os.storage.StorageManager;
 import android.provider.Settings;
 import androidx.annotation.NonNull;
-import androidx.core.content.FileProvider;
 
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.webkit.MimeTypeMap;
 
-import com.google.android.diskusage.BuildConfig;
 import com.google.android.diskusage.datasource.fast.LegacyFileImpl;
 import com.google.android.diskusage.datasource.fast.StatFsSourceImpl;
 import com.google.android.diskusage.filesystem.Apps2SDLoader;

--- a/app/src/main/java/com/google/android/diskusage/ui/filemanagers/DefaultFilemanager.kt
+++ b/app/src/main/java/com/google/android/diskusage/ui/filemanagers/DefaultFilemanager.kt
@@ -1,0 +1,16 @@
+package com.google.android.diskusage.ui.filemanagers
+
+import android.app.Activity
+import android.content.Intent
+import com.google.android.diskusage.filesystem.entity.FileSystemEntry
+
+class DefaultFilemanager(mEntry: FileSystemEntry, mActivity: Activity) : ExternalFileManager(mEntry, mActivity) {
+
+    override fun getFilemanagerIntent(): Intent {
+        var intent = Intent(Intent.ACTION_VIEW)
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        intent.setDataAndType(getUri(), "inode/directory")
+        return intent
+    }
+
+}

--- a/app/src/main/java/com/google/android/diskusage/ui/filemanagers/DocumentsUIFilemanager.kt
+++ b/app/src/main/java/com/google/android/diskusage/ui/filemanagers/DocumentsUIFilemanager.kt
@@ -1,0 +1,33 @@
+package com.google.android.diskusage.ui.filemanagers
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.provider.DocumentsContract
+import android.util.Log
+import com.google.android.diskusage.filesystem.entity.FileSystemEntry
+
+class DocumentsUIFilemanager(mEntry: FileSystemEntry, mActivity: Activity) : ExternalFileManager(mEntry, mActivity) {
+
+    override fun getFilemanagerIntent(): Intent {
+        // Documentation for the reason behind the replacements
+        // https://stackoverflow.com/a/75299820
+        var path = mEntry.absolutePath()
+        path = path.replaceFirst("storage/emulated/0", "primary")
+        path = path.replaceFirst("/", "")
+        path = path.replaceFirst("/", "%3A")
+        path = path.replace("/", "%2F")
+
+        var intent = Intent(Intent.ACTION_VIEW)
+        var uri = Uri.parse(
+            "content://com.android.externalstorage.documents/document/" + path
+        )
+
+        Log.e("TAG", mEntry.absolutePath())
+        Log.e("TAG", uri.toString())
+
+        intent.setDataAndType(uri, DocumentsContract.Document.MIME_TYPE_DIR);
+        return intent
+    }
+
+}

--- a/app/src/main/java/com/google/android/diskusage/ui/filemanagers/ExternalFileManager.kt
+++ b/app/src/main/java/com/google/android/diskusage/ui/filemanagers/ExternalFileManager.kt
@@ -1,0 +1,53 @@
+package com.google.android.diskusage.ui.filemanagers
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.FileUriExposedException
+import androidx.core.content.FileProvider
+import com.google.android.diskusage.BuildConfig
+import com.google.android.diskusage.filesystem.entity.FileSystemEntry
+import java.io.File
+
+abstract class ExternalFileManager(var mEntry: FileSystemEntry, var mActivity: Activity) {
+
+
+    companion object {
+        fun getUri(entry: FileSystemEntry, context: Context): Uri {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                return FileProvider.getUriForFile(
+                    context,
+                    BuildConfig.APPLICATION_ID + ".provider",
+                    File(entry.absolutePath()))
+            }
+            return Uri.fromFile(File(entry.absolutePath()))
+        }
+    }
+
+
+    abstract fun getFilemanagerIntent(): Intent
+
+
+    fun getUri(): Uri {
+        return Companion.getUri(mEntry, mActivity)
+    }
+
+    fun open(): Boolean {
+        try {
+            mActivity.startActivity(getFilemanagerIntent())
+            return true
+        } catch (ignored: ActivityNotFoundException) {
+            ignored.printStackTrace()
+        } catch (ignored: FileUriExposedException) {
+            ignored.printStackTrace()
+        }
+        return false
+    }
+
+
+
+
+}

--- a/app/src/main/java/com/google/android/diskusage/ui/filemanagers/OldAstro.kt
+++ b/app/src/main/java/com/google/android/diskusage/ui/filemanagers/OldAstro.kt
@@ -1,0 +1,17 @@
+package com.google.android.diskusage.ui.filemanagers
+
+import android.app.Activity
+import android.content.Intent
+import com.google.android.diskusage.filesystem.entity.FileSystemEntry
+
+class OldAstro(mEntry: FileSystemEntry, mActivity: Activity) : ExternalFileManager(mEntry, mActivity) {
+
+    override fun getFilemanagerIntent(): Intent {
+        val intent = Intent(Intent.ACTION_VIEW)
+        intent.addCategory(Intent.CATEGORY_DEFAULT)
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        intent.setDataAndType(getUri(), "vnd.android.cursor.item/com.metago.filemanager.dir")
+        return intent
+    }
+
+}

--- a/app/src/main/java/com/google/android/diskusage/ui/filemanagers/OpenIntents.kt
+++ b/app/src/main/java/com/google/android/diskusage/ui/filemanagers/OpenIntents.kt
@@ -1,0 +1,16 @@
+package com.google.android.diskusage.ui.filemanagers
+
+import android.app.Activity
+import android.content.Intent
+import com.google.android.diskusage.filesystem.entity.FileSystemEntry
+
+class OpenIntents(mEntry: FileSystemEntry, mActivity: Activity) : ExternalFileManager(mEntry, mActivity) {
+
+    override fun getFilemanagerIntent(): Intent {
+        val intent = Intent("org.openintents.action.VIEW_DIRECTORY")
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        intent.setData(getUri())
+        return intent
+    }
+
+}

--- a/app/src/main/java/com/google/android/diskusage/ui/filemanagers/OpenIntentsPickDir.kt
+++ b/app/src/main/java/com/google/android/diskusage/ui/filemanagers/OpenIntentsPickDir.kt
@@ -1,0 +1,25 @@
+package com.google.android.diskusage.ui.filemanagers
+
+import android.app.Activity
+import android.content.Intent
+import com.google.android.diskusage.R
+import com.google.android.diskusage.filesystem.entity.FileSystemEntry
+
+class OpenIntentsPickDir(mEntry: FileSystemEntry, mActivity: Activity) : ExternalFileManager(mEntry, mActivity) {
+
+    override fun getFilemanagerIntent(): Intent {
+        val intent = Intent("org.openintents.action.PICK_DIRECTORY")
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        intent.setData(getUri())
+        intent.putExtra(
+            "org.openintents.extra.TITLE",
+            mActivity.getString(R.string.title_in_oi_file_manager)
+        )
+        intent.putExtra(
+            "org.openintents.extra.BUTTON_TEXT",
+            mActivity.getString(R.string.button_text_in_oi_file_manager)
+        )
+        return intent
+    }
+
+}


### PR DESCRIPTION
This pull request updates the way DocumentsUI parses the URI, so that the default filepicker works properly.


I have only tested this with a pixel 7 (api 34).
I assume that my current aproach does not fix it for most people, since i partially hardcode the final path.
I would like some help with fixing that issue.


The second improvement is that i remove the code to open a different filemanager from the view-function, into their own abstract class. This allows for easy and quick access to specific apps without cluttering the main function.